### PR TITLE
allow full package names for Plack Middleware

### DIFF
--- a/lib/Perl/PrereqScanner/NotQuiteLite/Parser/Plack.pm
+++ b/lib/Perl/PrereqScanner/NotQuiteLite/Parser/Plack.pm
@@ -35,6 +35,7 @@ sub parse_enable_args {
   if ($module =~ s/^\+//) {
     $c->add($module => 0);
   } else {
+    $module =~ s/^Plack::Middleware:://;
     $c->add("Plack::Middleware::".$module => 0);
   }
 }
@@ -53,6 +54,7 @@ sub parse_enable_if_args {
   if ($module =~ s/^\+//) {
     $c->add($module => 0);
   } else {
+    $module =~ s/^Plack::Middleware:://;
     $c->add("Plack::Middleware::".$module => 0);
   }
 }

--- a/t/plack.t
+++ b/t/plack.t
@@ -19,6 +19,13 @@ builder {
 };
 END
 
+test('enable full', <<'END', {'Plack::Builder' => 0, 'Plack::Middleware::Foo' => 0});
+use Plack::Builder;
+builder {
+  enable 'Plack::Middleware::Foo';
+}
+END
+
 test('enable_if', <<'END', {'Plack::Builder' => 0, 'Plack::Middleware::Foo' => 0});
 use Plack::Builder;
 builder {
@@ -33,6 +40,13 @@ builder {
 };
 END
 
+test('enable_if full', <<'END', {'Plack::Builder' => 0, 'Plack::Middleware::Foo' => 0});
+use Plack::Builder;
+builder {
+  enable_if { $_[0]->{REMOTE_ADDR} eq '127.0.0.1' } 'Plack::Middleware::Foo';
+};
+END
+
 test('enable_if, sub', <<'END', {'Plack::Builder' => 0, 'Plack::Middleware::Foo' => 0});
 use Plack::Builder;
 builder {
@@ -44,6 +58,13 @@ test('enable_if plus, sub', <<'END', {'Plack::Builder' => 0, 'Foo' => 0});
 use Plack::Builder;
 builder {
   enable_if sub { $_[0]->{REMOTE_ADDR} eq '127.0.0.1' }, '+Foo';
+};
+END
+
+test('enable_if full, sub', <<'END', {'Plack::Builder' => 0, 'Plack::Middleware::Foo' => 0});
+use Plack::Builder;
+builder {
+  enable_if sub { $_[0]->{REMOTE_ADDR} eq '127.0.0.1' }, 'Plack::Middleware::Foo';
 };
 END
 


### PR DESCRIPTION
`Plack::Builder` only prefixes the provided package name with
`Plack::Middleware::` if it does not already have that as a prefix.

Thus, `enable 'Plack::Middleware::Foo'` was parsing here and adding
_another_ `P:M:` to the start, giving us `P:M:P:M:Foo`.

Easiest fix is to strip the prefix if it already exists, as we're going
to add it back on again in the next line anyways.